### PR TITLE
Forcing white inpaint brush

### DIFF
--- a/sd35-inpainting-gradio/app.py
+++ b/sd35-inpainting-gradio/app.py
@@ -65,7 +65,7 @@ class StableUI:
         return images[0]
 
     def _start_gradio(self):
-        white_brush = gr.Brush(colors=['#FFFFFF'], color_mode='fixed')
+        white_brush = gr.Brush(default_color='#FFFFFF', colors=['#FFFFFF'], color_mode='fixed')
 
         gr.Interface(
             self._predict,


### PR DESCRIPTION
Fixed! And wow, for some reason it now works better than it did before this issue. Now even background replacement works
An unfortunate limitation is that the replaced background needs to somewhat resemble the original background
<img width="1549" alt="Screenshot 2025-02-07 at 6 12 00 PM" src="https://github.com/user-attachments/assets/cbe21dcf-7c79-4f27-8806-fd797701da8b" />
<img width="1582" alt="Screenshot 2025-02-07 at 6 10 10 PM" src="https://github.com/user-attachments/assets/d3735a98-4da7-4be6-95b7-b763532b8972" />
<img width="1702" alt="Screenshot 2025-02-07 at 6 08 54 PM" src="https://github.com/user-attachments/assets/4cafd161-78f3-43f0-a2c0-41f7ffd01589" />
