### PR TITLE
Enforcing inpainting dimensions

### DIFF
--- a/sd35-inpainting-gradio/app.py
+++ b/sd35-inpainting-gradio/app.py
@@ -59,6 +59,15 @@ class StableUI:
         mask_image = mask['layers'][0].convert("RGB")
         width, height = image.size
 
+        constrained_dimension = min(width, height)
+        if constrained_dimension < 512:
+            width = int(512 * width / constrained_dimension)
+            height = int(512 * height / constrained_dimension)
+
+            new_dimensions = (width, height)
+            image = image.resize(new_dimensions)
+            mask_image = mask_image.resize(new_dimensions)
+
         image.show()
         mask_image.show()
 


### PR DESCRIPTION
![73](https://github.com/user-attachments/assets/63800fd9-621a-47d2-883f-fa6625c832cc)
![73 output](https://github.com/user-attachments/assets/0e65a31e-b87a-44d1-8d51-c3e9b409ff47)
<img width="1186" alt="Screenshot 2025-02-13 at 1 52 46 PM" src="https://github.com/user-attachments/assets/48fd6015-7e1d-4fb5-96de-523122e80f21" />

Fixed the following issue: The minimum image dimensions must be bigger than 512x512, so rectangular images cannot have a side shorter than 512 pixels